### PR TITLE
Minor change for clarification

### DIFF
--- a/unbound_manager.sh
+++ b/unbound_manager.sh
@@ -701,7 +701,7 @@ welcome_message() {
                                 # If either of the two customising files exist then no point in prompting the restore
                                 if [ ! -f /opt/share/unbound/configs/unbound.conf.add ] && [ ! -f /opt/share/unbound/configs/unbound.postconf ];then      # V2.12 Hotfix v2.10
 
-                                        echo -e "\a\nDo you want to KEEP your current unbound configuration? ${cRESET}('${cBMAG}${PREINSTALLCONFIG}${cRESET}')\n\n\tReply$cBRED 'y'$cRESET to ${cBRED}KEEP ${cRESET}or press $cBGRE[Enter] to use new downloaded 'unbound.conf'$cRESET"
+                                        echo -e "\a\nDo you want to KEEP your current unbound configuration? ${cRESET}('${cBMAG}${PREINSTALLCONFIG}${cRESET}')\n\n\tReply$cBRED 'y'$cRESET to ${cBRED}KEEP ${cRESET}or press ${cBGRE}[Enter] to use new downloaded 'unbound.conf'$cRESET"
                                         read -r "ANS"
                                         if [ "$ANS" == "y"  ];then                      # v1.27
                                             cp "/opt/share/unbound/configs/$PREINSTALLCONFIG" ${CONFIG_DIR}unbound.conf # Restore previous config


### PR DESCRIPTION
Since you are not dealing with an array in this instance I think it's safe to make this change for clarity. I believe that the busybox dash implementation interprets and displays the original line as intended. However, without an ignore directive _shellcheck -S error_ shows error SC1087 for the original line (704).

Explanation:
https://github.com/koalaman/shellcheck/wiki/SC1087