### PR TITLE
Update unbound.conf

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -114,6 +114,9 @@ incoming-num-tcp: 600
 outgoing-num-tcp: 100
 ip-ratelimit: 0                                  # v1.04 as per @L&LD as it impacts ipleak.net?
 edns-buffer-size: 1472                           # v1.01 as per @dave14305 minimal config
+max-udp-size: 3072                               # mitigate DDOS threats when using dnssec, reduce potential for fragmentation.
+outgoing-port-avoid: 0-32767                     # avoid grabbing udp ports commonly used
+outgoing-port-permit: 32768-65535                # ports to permit
 
 # Ensure kernel buffer is large enough to not lose messages in traffic spikes
 #so-rcvbuf: 1m                                   # v1.05 Martineau see DEFAULT /proc/sys/net/core/rmem_default

--- a/unbound.conf
+++ b/unbound.conf
@@ -115,8 +115,8 @@ outgoing-num-tcp: 100
 ip-ratelimit: 0                                  # v1.04 as per @L&LD as it impacts ipleak.net?
 edns-buffer-size: 1472                           # v1.01 as per @dave14305 minimal config
 max-udp-size: 3072                               # mitigate DDOS threats when using dnssec, reduce potential for fragmentation.
-outgoing-port-avoid: 0-32767                     # avoid grabbing udp ports commonly used
-outgoing-port-permit: 32768-65535                # ports to permit
+#outgoing-port-avoid: 0-32767                     # avoid grabbing udp ports commonly used / only for users with UDP port availability problems
+#outgoing-port-permit: 32768-65535                # ports to permit / Not necessary if port-avoid is not used. limits port randomization. 
 
 # Ensure kernel buffer is large enough to not lose messages in traffic spikes
 #so-rcvbuf: 1m                                   # v1.05 Martineau see DEFAULT /proc/sys/net/core/rmem_default

--- a/unbound.conf
+++ b/unbound.conf
@@ -109,6 +109,7 @@ prefetch-key: yes
 minimal-responses: yes
 serve-expired: yes
 serve-expired-ttl: 86400                         # v1.12 as per @juched
+serve-expired-ttl-reset: yes                     # Set the TTL of expired records to the serve-expired-ttl value after a failed attempt to retrieve the record from upstream.
 incoming-num-tcp: 600
 outgoing-num-tcp: 100
 ip-ratelimit: 0                                  # v1.04 as per @L&LD as it impacts ipleak.net?


### PR DESCRIPTION
Set the TTL of expired records to the serve-expired-ttl value after a failed attempt to retrieve the record from upstream. This makes sure that the expired records will be served as  long as there are queries for it.  Default is "no".