### PR TITLE
Update unbound_SafeSearch.sh

### DIFF
--- a/unbound_SafeSearch.sh
+++ b/unbound_SafeSearch.sh
@@ -10,8 +10,8 @@ echo -e "\n# $(date)\n# Google Safe Search: "$URL >> "${FN}"    # Martineau Hack
 DOMAINS=$(curl $URL 2>/dev/null)
 for DOMAIN in $DOMAINS;do
     DOMAIN=$(echo $DOMAIN | cut -c 2-)
-    printf 'local-zone: "%s" redirect \n' $DOMAIN >> "${FN}"
-    printf 'local-data: "%s CNAME forcesafesearch.google.com" \n' $DOMAIN >> "${FN}"
+    #printf 'local-zone: "%s" redirect \n' $DOMAIN >> "${FN}" ## Disable so android properly recieves push notifications
+    #printf 'local-data: "%s CNAME forcesafesearch.google.com" \n' $DOMAIN >> "${FN}" ## Disable so android properly recieves push notifications
     printf 'local-zone: "www.%s" redirect \n' $DOMAIN >> "${FN}"
     printf 'local-data: "www.%s CNAME forcesafesearch.google.com" \n' $DOMAIN >> "${FN}"
 done

--- a/unbound_SafeSearch.sh
+++ b/unbound_SafeSearch.sh
@@ -17,7 +17,7 @@ for DOMAIN in $DOMAINS;do
 done
 echo -e "\n# Youtube Safe Search:" >> "${FN}"                   # Martineau Hack
 #for DOMAIN in youtube; do
-    for PREFIX in youtube www.youtube m.youtube youtubei.googleapis youtube.googleapis youtube-nocookie www.youtube-nocookie;do  # Martineau Hac
+    for PREFIX in www.youtube m.youtube youtubei.googleapis youtube.googleapis www.youtube-nocookie;do  # Martineau Hac
         printf 'local-zone: "%s.com" redirect \n' $PREFIX >> "${FN}"
         printf 'local-data: "%s.com CNAME restrictmoderate.youtube.com" \n' $PREFIX >> "${FN}"
     done

--- a/unbound_SafeSearch.sh
+++ b/unbound_SafeSearch.sh
@@ -10,8 +10,6 @@ echo -e "\n# $(date)\n# Google Safe Search: "$URL >> "${FN}"    # Martineau Hack
 DOMAINS=$(curl $URL 2>/dev/null)
 for DOMAIN in $DOMAINS;do
     DOMAIN=$(echo $DOMAIN | cut -c 2-)
-    #printf 'local-zone: "%s" redirect \n' $DOMAIN >> "${FN}" ## Disable so android properly recieves push notifications
-    #printf 'local-data: "%s CNAME forcesafesearch.google.com" \n' $DOMAIN >> "${FN}" ## Disable so android properly recieves push notifications
     printf 'local-zone: "www.%s" redirect \n' $DOMAIN >> "${FN}"
     printf 'local-data: "www.%s CNAME forcesafesearch.google.com" \n' $DOMAIN >> "${FN}"
 done


### PR DESCRIPTION
The redirect for .google.com is over kill, only "www." needs to be redirected for proper safe search enforcement. including .google.com breaks android push notifications and other necessary google.com functions.